### PR TITLE
Implement PubsubAdapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,28 @@
-# The Kisi Backend Code Challenge
-
-This repository can be used as a starting point for the Kisi Backend Code Challenge. Feel free to replace this `README.md` with your own when you submit your solution.
+# The Kisi Backend Code Challenge (Sky's Version)
 
 This repository contains:
 - A bare-bones Rails 6 API app with a `Gemfile` that contains the neccessary libraries for the project.
-- A configured adapter ([lib/active_job/queue_adapters/pubsub_adapter.rb](lib/active_job/queue_adapters/pubsub_adapter.rb)) to enqueue jobs. Use as a starting point for your own code.
-- A rake task ([lib/tasks/worker.rake](lib/tasks/worker.rake)) to launch the worker process. Use as a starting point for your own code.
-- A class ([lib/pubsub.rb](lib/pubsub.rb)) that wraps the GCP Pub/Sub client. Use as as a starting point for your own code.
+- A configured adapter ([lib/active_job/queue_adapters/pubsub_adapter.rb](lib/active_job/queue_adapters/pubsub_adapter.rb)) to enqueue jobs. 
+- A rake task ([lib/tasks/worker.rake](lib/tasks/worker.rake)) to launch the worker process.
+- A class ([lib/pubsub.rb](lib/pubsub.rb)) that wraps the GCP Pub/Sub client. 
 - A [Dockerfile](Dockerfile) and a [docker-compose.yml](docker-compose.yml) configured to spin up necessary services (web server, worker, pub/sub emulator).
 
-The reason we provide a Docker-setup is so that you *don't* have to set up a *real* GCP project, and can instead use the emulator. If you prefer *not* to use Docker, you can ignore the following text.
+To start run `bundle install`.
 
-To start all services, make sure you have [Docker](https://www.docker.com/products/docker-desktop/) installed and run:
-```
-$ docker compose up
-```
+To run the worker use the command:
+`TOPIC_NAME=<put-your-topic-name-here> GOOGLE_APPLICATION_CREDENTIALS=credentials.json rails worker:run`
 
-If you prefer to start each service individually, run:
-```
-$ docker compose up web
-$ docker compose up worker
-$ docker compose up pubsub
-```
+To run the rake task to enqueue 5 sample jobs:
+`TOPIC_NAME=<put-your-topic-name-here> GOOGLE_APPLICATION_CREDENTIALS=credentials.json rails worker:enqueue_jobs`
 
-To rebuild an image, run:
-```
-$ docker compose build web
-```
+Make sure that the `credentials.json` file contains valid google pubsub credentials that will allow you access to your project.
 
-To restart the worker, i.e. after a code change:
-```
-$ docker compose restart worker
-```
-
-To start a console:
-```
-$ docker compose run --rm worker bin/rails console
-```
-
-If you want to debug using `pry` and breakpoints, you might want to start a service manually instead:
-```
-$ docker compose run --rm worker bash
-# bin/rails worker:run
+Changes made by the developer:
+1. Implement PubsubAdapter and register the ActiveJob queue adapter in `application.rb`
+2. Implement rake task to dequeue and execute pending jobs by pulling the messages from Google Cloud Pubsub.
+3. Create a morgue queue topic and publish failed jobs after trying at most 2 times and waiting for 5 minutes apart.
+4. For the subscriptions, the developer enabled the `enable_exactly_once_delivery` which means the message cannot be redelivered once it has been successfully acknowledged.
+5. Create a rake task to enqueue jobs to the topic (at least five jobs per second).
 ```
 
 If you run docker with a VM (e.g. Docker Desktop for Mac) we recommend you allocate at least 2GB Memory

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ This repository contains:
 To start run `bundle install`.
 
 To run the worker use the command:
-`TOPIC_NAME=<put-your-topic-name-here> GOOGLE_APPLICATION_CREDENTIALS=credentials.json rails worker:run`
+`GOOGLE_APPLICATION_CREDENTIALS=credentials.json rails worker:run`
 
 To run the rake task to enqueue 5 sample jobs:
-`TOPIC_NAME=<put-your-topic-name-here> GOOGLE_APPLICATION_CREDENTIALS=credentials.json rails worker:enqueue_jobs`
+`GOOGLE_APPLICATION_CREDENTIALS=credentials.json rails worker:enqueue_jobs`
 
 Make sure that the `credentials.json` file contains valid google pubsub credentials that will allow you access to your project.
 

--- a/app/jobs/pubsub_job.rb
+++ b/app/jobs/pubsub_job.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class PubsubJob < ApplicationJob
-  # self.queue_adapter = :pubsub
-  retry_on(StandardError, wait: 5.second, attempts: 2)
+  retry_on(StandardError, wait: 5.minute, attempts: 2)
 
   def perform(*args)
     # puts("\n [PubsubJob][perform-start] #{args}")

--- a/app/jobs/pubsub_job.rb
+++ b/app/jobs/pubsub_job.rb
@@ -5,14 +5,12 @@ class PubsubJob < ApplicationJob
   retry_on(StandardError, wait: 5.second, attempts: 2)
 
   def perform(*args)
-    ActiveSupport::Notifications.instrument("perform.pubsub_job") do
-      # puts("\n [PubsubJob][perform-start] #{args}")
-      sleeping_time = rand(5)
-      puts("\n [PubsubJob][sleeping_time]: #{sleeping_time} => #{(sleeping_time % 2).zero?}")
-      raise(StandardError) if (sleeping_time % 2).zero?
+    # puts("\n [PubsubJob][perform-start] #{args}")
+    sleeping_time = rand(5)
+    puts("\n [PubsubJob][sleeping_time]: #{sleeping_time} => #{(sleeping_time % 2).zero?}")
+    raise(StandardError) if (sleeping_time % 2).zero?
 
-      sleep(sleeping_time)
-      # puts("\n [PubsubJob][perform-end] #{args}")
-    end
+    sleep(sleeping_time)
+    # puts("\n [PubsubJob][perform-end] #{args}")
   end
 end

--- a/app/jobs/pubsub_job.rb
+++ b/app/jobs/pubsub_job.rb
@@ -2,18 +2,17 @@
 
 class PubsubJob < ApplicationJob
   # self.queue_adapter = :pubsub
-  queue_as(:default)
-  retry_on(StandardError, wait: 5.minute, attempts: 2)
+  retry_on(StandardError, wait: 5.second, attempts: 2)
 
   def perform(*args)
-    puts("\n [PubsubJob][perform-start] #{args}")
+    ActiveSupport::Notifications.instrument("perform.pubsub_job") do
+      # puts("\n [PubsubJob][perform-start] #{args}")
+      sleeping_time = rand(5)
+      puts("\n [PubsubJob][sleeping_time]: #{sleeping_time} => #{(sleeping_time % 2).zero?}")
+      raise(StandardError) if (sleeping_time % 2).zero?
 
-    sleeping_time = rand(5)
-    puts("\n [PubsubJob][sleeping_time]: #{sleeping_time} => #{(sleeping_time % 2).zero?}")
-    raise(StandardError) if (sleeping_time % 2).zero?
-
-    sleep(sleeping_time)
-
-    puts("\n [PubsubJob][perform-end] #{args}")
+      sleep(sleeping_time)
+      # puts("\n [PubsubJob][perform-end] #{args}")
+    end
   end
 end

--- a/app/jobs/pubsub_job.rb
+++ b/app/jobs/pubsub_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class PubsubJob < ApplicationJob
+  # self.queue_adapter = :pubsub
+  queue_as(:default)
+  retry_on(StandardError, wait: 5.minute, attempts: 2)
+
+  def perform(*args)
+    puts("\n [PubsubJob][perform-start] #{args}")
+
+    sleeping_time = rand(5)
+    puts("\n [PubsubJob][sleeping_time]: #{sleeping_time} => #{(sleeping_time % 2).zero?}")
+    raise(StandardError) if (sleeping_time % 2).zero?
+
+    sleep(sleeping_time)
+
+    puts("\n [PubsubJob][perform-end] #{args}")
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,5 +44,9 @@ module KisiApiChallenge
 
     # Configures the custom queue adapter.
     config.active_job.queue_adapter = :pubsub
+
+    def topic_name
+      ENV["TOPIC_NAME"] || "topic-1"
+    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,8 +45,6 @@ module KisiApiChallenge
     # Configures the custom queue adapter.
     config.active_job.queue_adapter = :pubsub
 
-    def topic_name
-      ENV["TOPIC_NAME"] || "topic-1"
-    end
+    config.active_job.queue_name = "topic-kisi"
   end
 end

--- a/config/initializers/notifications.rb
+++ b/config/initializers/notifications.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-ActiveSupport::Notifications.subscribe("perform.pubsub_job") do |name, started, finished, _unique_id, _data|
+ActiveSupport::Notifications.subscribe("perform.active_job") do |name, started, finished, _unique_id, _data|
   logger(name, started, finished)
 end
 
-ActiveSupport::Notifications.subscribe("enqueue.pubsub_adapter") do |name, started, finished, _unique_id, _data|
+ActiveSupport::Notifications.subscribe("enqueue.active_job") do |name, started, finished, _unique_id, _data|
   logger(name, started, finished)
 end
 
-ActiveSupport::Notifications.subscribe("enqueue_at.pubsub_adapter") do |name, started, finished, _unique_id, _data|
+ActiveSupport::Notifications.subscribe("enqueue_at.active_job") do |name, started, finished, _unique_id, _data|
   logger(name, started, finished)
 end
 

--- a/config/initializers/notifications.rb
+++ b/config/initializers/notifications.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+ActiveSupport::Notifications.subscribe("perform.pubsub_job") do |name, started, finished, _unique_id, _data|
+  logger(name, started, finished)
+end
+
+ActiveSupport::Notifications.subscribe("enqueue.pubsub_adapter") do |name, started, finished, _unique_id, _data|
+  logger(name, started, finished)
+end
+
+ActiveSupport::Notifications.subscribe("enqueue_at.pubsub_adapter") do |name, started, finished, _unique_id, _data|
+  logger(name, started, finished)
+end
+
+ActiveSupport::Notifications.subscribe("publish_job.pubsub_adapter") do |name, started, finished, _unique_id, _data|
+  logger(name, started, finished)
+end
+
+def logger(name, started, finished)
+  puts("\n [NOTIF-SUBSCRIBE][#{name}] Received! (started: #{started}, finished: #{finished})")
+end

--- a/credentials.json
+++ b/credentials.json
@@ -1,0 +1,13 @@
+{
+  "type": "service_account",
+  "project_id": "<insert-value-here>",
+  "private_key_id": "<insert-value-here>",
+  "private_key": "<insert-value-here>",
+  "client_email": "<insert-value-here>",
+  "client_id": "<insert-value-here>",
+  "auth_uri": "<insert-value-here>",
+  "token_uri": "<insert-value-here>",
+  "auth_provider_x509_cert_url": "<insert-value-here>",
+  "client_x509_cert_url": "<insert-value-here>",
+  "universe_domain": "<insert-value-here>"
+}

--- a/lib/active_job/queue_adapters/pubsub_adapter.rb
+++ b/lib/active_job/queue_adapters/pubsub_adapter.rb
@@ -7,8 +7,10 @@ module ActiveJob
       #
       # @param [ActiveJob::Base] job The job to be performed.
       def enqueue(job)
-        puts("\n [PubsubAdapter][enqueue]: #{job.inspect}")
-        publish_job(job)
+        ActiveSupport::Notifications.instrument("enqueue.pubsub_adapter") do
+          # puts("\n [PubsubAdapter][enqueue]: #{job.inspect}")
+          publish_job(job)
+        end
       end
 
       # Enqueue a job to be performed at a certain time.
@@ -16,23 +18,23 @@ module ActiveJob
       # @param [ActiveJob::Base] job The job to be performed.
       # @param [Float] timestamp The time to perform the job.
       def enqueue_at(job, timestamp)
-        puts("\n [PubsubAdapter][enqueue_at]: #{job.inspect} timestamp: #{timestamp}")
-        publish_job(job, timestamp)
-      end
-
-       # push job to the topic
-      def publish_job(job, timestamp = 0)
-        puts("\n [PubsubAdapter][publish_job]: #{job.inspect}")
-        serialized_job = job.serialize
-        Pubsub.new.topic(topic_name).publish(JSON.dump(serialized_job), { timestamp: timestamp })
-      rescue StandardError => e
-        puts("[ERROR][PubsubAdapter] Received error while publishing: #{e.message}")
+        ActiveSupport::Notifications.instrument("enqueue_at.pubsub_adapter") do
+          # puts("\n [PubsubAdapter][enqueue_at]: #{job.inspect} timestamp: #{timestamp}")
+          publish_job(job, timestamp)
+        end
       end
 
       private
 
-      def topic_name
-        @topic_name ||= Rails.application.topic_name
+      # push job to the topic
+      def publish_job(job, timestamp = 0)
+        ActiveSupport::Notifications.instrument("publish_job.pubsub_adapter") do
+          # puts("\n [PubsubAdapter][publish_job]: #{job.inspect}")
+          serialized_job = job.serialize
+          Pubsub.new.topic(job.queue_name).publish(JSON.dump(serialized_job), { timestamp: timestamp })
+        end
+      rescue StandardError => e
+        puts("[ERROR][PubsubAdapter] Received error while publishing: #{e.message}")
       end
     end
   end

--- a/lib/active_job/queue_adapters/pubsub_adapter.rb
+++ b/lib/active_job/queue_adapters/pubsub_adapter.rb
@@ -7,10 +7,8 @@ module ActiveJob
       #
       # @param [ActiveJob::Base] job The job to be performed.
       def enqueue(job)
-        ActiveSupport::Notifications.instrument("enqueue.pubsub_adapter") do
-          # puts("\n [PubsubAdapter][enqueue]: #{job.inspect}")
-          publish_job(job)
-        end
+        # puts("\n [PubsubAdapter][enqueue]: #{job.inspect}")
+        publish_job(job)
       end
 
       # Enqueue a job to be performed at a certain time.
@@ -18,10 +16,8 @@ module ActiveJob
       # @param [ActiveJob::Base] job The job to be performed.
       # @param [Float] timestamp The time to perform the job.
       def enqueue_at(job, timestamp)
-        ActiveSupport::Notifications.instrument("enqueue_at.pubsub_adapter") do
-          # puts("\n [PubsubAdapter][enqueue_at]: #{job.inspect} timestamp: #{timestamp}")
-          publish_job(job, timestamp)
-        end
+        # puts("\n [PubsubAdapter][enqueue_at]: #{job.inspect} timestamp: #{timestamp}")
+        publish_job(job, timestamp)
       end
 
       private

--- a/lib/active_job/queue_adapters/pubsub_adapter.rb
+++ b/lib/active_job/queue_adapters/pubsub_adapter.rb
@@ -7,7 +7,8 @@ module ActiveJob
       #
       # @param [ActiveJob::Base] job The job to be performed.
       def enqueue(job)
-        raise(NotImplementedError)
+        puts("\n [PubsubAdapter][enqueue]: #{job.inspect}")
+        publish_job(job)
       end
 
       # Enqueue a job to be performed at a certain time.
@@ -15,7 +16,23 @@ module ActiveJob
       # @param [ActiveJob::Base] job The job to be performed.
       # @param [Float] timestamp The time to perform the job.
       def enqueue_at(job, timestamp)
-        raise(NotImplementedError)
+        puts("\n [PubsubAdapter][enqueue_at]: #{job.inspect} timestamp: #{timestamp}")
+        publish_job(job, timestamp)
+      end
+
+       # push job to the topic
+      def publish_job(job, timestamp = 0)
+        puts("\n [PubsubAdapter][publish_job]: #{job.inspect}")
+        serialized_job = job.serialize
+        Pubsub.new.topic(topic_name).publish(JSON.dump(serialized_job), { timestamp: timestamp })
+      rescue StandardError => e
+        puts("[ERROR][PubsubAdapter] Received error while publishing: #{e.message}")
+      end
+
+      private
+
+      def topic_name
+        @topic_name ||= Rails.application.topic_name
       end
     end
   end

--- a/lib/pubsub.rb
+++ b/lib/pubsub.rb
@@ -1,14 +1,29 @@
 # frozen_string_literal: true
 
 require("google/cloud/pubsub")
+require("json")
 
 class Pubsub
+
+  def initialize; end
+
   # Find or create a topic.
   #
   # @param topic [String] The name of the topic to find or create
   # @return [Google::Cloud::PubSub::Topic]
   def topic(name)
+    puts("\n [PubsubAdapter][topic]: #{name}")
     client.topic(name) || client.create_topic(name)
+  end
+
+  # find or create new subsription
+  # @param name [String] The name of the topic to subscribe
+  # we prefix the subscription name to avoid confusion
+  def subscribe(name)
+    puts("\n [PubsubAdapter][subscribe]: #{name}")
+    prefixed_name = "subscription-#{name}"
+
+    topic(name).subscription(prefixed_name) || topic(name).subscribe(prefixed_name, enable_exactly_once_delivery: true)
   end
 
   private
@@ -17,6 +32,6 @@ class Pubsub
   #
   # @return [Google::Cloud::PubSub]
   def client
-    @client ||= Google::Cloud::PubSub.new(project_id: "code-challenge")
+    @client ||= Google::Cloud::PubSub.new #(project_id: "code-challenge")
   end
 end

--- a/lib/tasks/worker.rake
+++ b/lib/tasks/worker.rake
@@ -2,7 +2,7 @@
 
 require("concurrent")
 
-MAX_DELAY = 1.minutes
+MAX_DELAY = 5.minutes
 TOPIC_NAME = "topic-kisi"
 
 namespace(:worker) do
@@ -55,11 +55,12 @@ namespace(:worker) do
         puts("\n [LISTEN] Processing right away....")
         process_message(message, pubsub)
       else
-        delay = message.attributes['timestamp'].to_i - Time.now.to_i
+        delay = [message.attributes['timestamp'].to_i - Time.now.to_i, MAX_DELAY.to_i].min
         puts("\n [LISTEN] Will be processed after #{delay}s")
         message.modify_ack_deadline!(delay)
       end
     end
+
     # Propagate expection from child threads to the main thread as soon as it is
     # raised. Exceptions happened in the callback thread are collected in the
     # callback thread pool and do not propagate to the main thread

--- a/lib/tasks/worker.rake
+++ b/lib/tasks/worker.rake
@@ -3,6 +3,7 @@
 require("concurrent")
 
 MAX_DELAY = 1.minutes
+TOPIC_NAME = "topic-kisi"
 
 namespace(:worker) do
   # if timestamp already passed or same as Time.now we will process the message
@@ -31,18 +32,12 @@ namespace(:worker) do
   def enqueue_failed_jobs(message, pubsub)
     puts("\n [WORKER][enqueue_failed_jobs] Message: #{message.data}")
 
-    failed_topic = "#{topic_name}-morgue-queue"
+    failed_topic = "#{TOPIC_NAME}-morgue-queue"
     pubsub.topic(failed_topic).publish(JSON.dump(message.data)) # publish failed messages to morgue topic
     pubsub.subscribe(failed_topic) # create a subscription
     puts("\n [WORKER][enqueue_failed_jobs] Done publishing: #{message.data}")
   rescue StandardError => e
     puts("\n [ERROR][WORKER][enqueue_failed_jobs]: Error publishing to morgue queue : #{e.message}")
-  end
-
-  # use the environment variable set for the topic name
-  # to make it configurable
-  def topic_name
-    @topic_name ||= Rails.application.topic_name
   end
 
   desc('Run the worker')
@@ -52,7 +47,7 @@ namespace(:worker) do
     puts("Worker starting...")
 
     pubsub = Pubsub.new
-    subscription = pubsub.subscribe(topic_name)
+    subscription = pubsub.subscribe(TOPIC_NAME)
 
     subscriber = subscription.listen do |message|
       puts("\n Received message: #{message.data}")

--- a/lib/tasks/worker.rake
+++ b/lib/tasks/worker.rake
@@ -1,13 +1,108 @@
 # frozen_string_literal: true
 
+require("concurrent")
+
+MAX_DELAY = 1.minutes
+
 namespace(:worker) do
-  desc("Run the worker")
+  # if timestamp already passed or same as Time.now we will process the message
+  def to_process?(timestamp)
+    remaining_time = [timestamp.to_i - Time.now.to_i, 0].max
+    remaining_time.zero?
+  end
+
+  # execution of job and acknowledging of message after execution
+  def process_message(message, pubsub)
+    puts("\n [WORKER][process_message] Time to process.")
+    message.modify_ack_deadline!(MAX_DELAY.to_i)
+
+    ActiveJob::Base.execute(JSON.parse(message.data))
+
+    # puts("\n [WORKER][process_message] About to acknowledge message #{message.message_id}.")
+    message.acknowledge!
+    puts("\n [WORKER][process_message] Message #{message.message_id} was acknowledged!")
+  rescue StandardError => e
+    puts("\n [ERROR][WORKER][process_message]: #{e.message} #{e.backtrace}")
+    enqueue_failed_jobs(message, pubsub)
+  end
+
+  # publish failed jobs to morgue queue
+  # create a subscription under the failed jobs topic
+  def enqueue_failed_jobs(message, pubsub)
+    puts("\n [WORKER][enqueue_failed_jobs] Message: #{message.data}")
+
+    failed_topic = "#{topic_name}-morgue-queue"
+    pubsub.topic(failed_topic).publish(JSON.dump(message.data)) # publish failed messages to morgue topic
+    pubsub.subscribe(failed_topic) # create a subscription
+    puts("\n [WORKER][enqueue_failed_jobs] Done publishing: #{message.data}")
+  rescue StandardError => e
+    puts("\n [ERROR][WORKER][enqueue_failed_jobs]: Error publishing to morgue queue : #{e.message}")
+  end
+
+  # use the environment variable set for the topic name
+  # to make it configurable
+  def topic_name
+    @topic_name ||= Rails.application.topic_name
+  end
+
+  desc('Run the worker')
   task(run: :environment) do
     # See https://googleapis.dev/ruby/google-cloud-pubsub/latest/index.html
 
     puts("Worker starting...")
 
-    # Block, letting processing threads continue in the background
+    pubsub = Pubsub.new
+    subscription = pubsub.subscribe(topic_name)
+
+    subscriber = subscription.listen do |message|
+      puts("\n Received message: #{message.data}")
+      if to_process?(message.attributes['timestamp'])
+        puts("\n [LISTEN] Processing right away....")
+        process_message(message, pubsub)
+      else
+        delay = message.attributes['timestamp'].to_i - Time.now.to_i
+        puts("\n [LISTEN] Will be processed after #{delay}s")
+        message.modify_ack_deadline!(delay)
+      end
+    end
+    # Propagate expection from child threads to the main thread as soon as it is
+    # raised. Exceptions happened in the callback thread are collected in the
+    # callback thread pool and do not propagate to the main thread
+    Thread.abort_on_exception = true
+
+    # Start background threads that will call the block passed to listen
+    begin
+      subscriber.start
+
+      # Block, letting processing threads continue in the background
+      sleep
+      # subscriber.stop.wait!
+    rescue StandardError => e
+      puts("\n [ERROR][LISTEN] Exception #{e.inspect}: #{e.message}")
+      raise('Stopped listening for messages.')
+    end
+  end
+
+  desc('Enqueue jobs')
+  task(enqueue_jobs: :environment) do
+    puts('Enqueuing jobs...')
+    index = 0
+    timer_task = Concurrent::TimerTask.new(execution_interval: 0.2) do |task|
+      puts("\n [TimerTask] Enqueue job #{index + 1}.....")
+      PubsubJob.perform_later("PubSubJob - #{rand(1000)}")
+      index += 1
+      # task.execution_interval += 1
+      if index >= 5
+        puts("\n [TimerTask] Stopping task...")
+        task.shutdown
+      end
+    rescue StandardError => e
+      puts("[ERROR][TimerTask]: #{e.message} #{e.backtrace}")
+      raise
+    end
+
+    timer_task.execute # blocking call - this task will stop itself
+
     sleep
   end
 end

--- a/test/jobs/pubsub_job_test.rb
+++ b/test/jobs/pubsub_job_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PubsubJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
**Changes made:**

1. Implement PubsubAdapter and register the ActiveJob queue adapter in application.rb
2. Implement rake task to dequeue and execute pending jobs by pulling the messages from Google Cloud Pubsub.
3. Create a morgue queue topic and publish failed jobs after trying at most 2 times and waiting for 5 minutes apart.
4. For the subscriptions, the developer enabled the `enable_exactly_once_delivery` which means the message cannot be redelivered once it has been successfully acknowledged.
5. Create a rake task to enqueue jobs to the topic (at least five jobs per second).


Sample enqueued jobs in Google PubSub:
<img width="1410" alt="Screen Shot 2023-08-17 at 6 39 12 PM" src="https://github.com/skysemilla/kisi-api-challenge/assets/30851227/84049442-b8c4-4785-94d5-c3f265aedd36">

Sample failed jobs in morgue queue:
<img width="1431" alt="image" src="https://github.com/skysemilla/kisi-api-challenge/assets/30851227/97e17096-f5b0-4aec-9e12-00dda41eec44">

